### PR TITLE
Use RbConfig instead of deprecated Config

### DIFF
--- a/lib/fssm/support.rb
+++ b/lib/fssm/support.rb
@@ -37,15 +37,15 @@ module FSSM::Support
     end
 
     def mac?
-      Config::CONFIG['target_os'] =~ /darwin/i
+      RbConfig::CONFIG['target_os'] =~ /darwin/i
     end
 
     def lion?
-      Config::CONFIG['target_os'] =~ /darwin11/i
+      RbConfig::CONFIG['target_os'] =~ /darwin11/i
     end
 
     def linux?
-      Config::CONFIG['target_os'] =~ /linux/i
+      RbConfig::CONFIG['target_os'] =~ /linux/i
     end
 
     def carbon_core?


### PR DESCRIPTION
This fixes the following warning under ruby 1.9.3-p0:
`fssm/lib/fssm/support.rb:40: Use RbConfig instead of obsolete and deprecated Config.`
