### PR TITLE
Fixed FSSM::Pathname.segments method to work correctly.

### DIFF
--- a/lib/fssm/pathname.rb
+++ b/lib/fssm/pathname.rb
@@ -20,10 +20,12 @@ module FSSM
 
     def segments
       path  = to_s
-      array = path.split(File::SEPARATOR)
-      array.delete('')
-      array.insert(0, File::SEPARATOR) if path[0, 1] == File::SEPARATOR
-      array[0] += File::SEPARATOR if path[0, 3] =~ SEPARATOR_PAT
+      array = []
+      while !Pathname.new(path).root? && !path.empty?
+        array.unshift File.basename(path)
+        path        = File.dirname(path)
+      end
+      array.unshift path unless path.empty?
       array
     end
 


### PR DESCRIPTION
Maybe, this problem occurs only under the cygwin environment.
The FSSM::Pathname.segments method did not work correctly. Therefore reconnection with join method failed to insert File::SEPARATOR into between each segment.

This problem makes failure for watch sub-command of compress.

before:

```
FSSM::Pathname.for("/tmp/foo").segments
# => ["//", "tmp", "foo"]
FSSM::Pathname.for("/tmp/foo").join("bar")
# => #<Pathname:/tmp/foo/bar>
# OK, no problem. But a result of segments is a little bit strange.

FSSM::Pathname.for("//host/share/foo").segments
# => ["/", "tmp", "foo"]
FSSM::Pathname.for("//host/share/foo").join("bar")
# => #<Pathname:/tmp/foo/bar>
# OK, no problem. But a result of segments is a little bit strange.

cache = FSSM::Tree::Cache.new
# => #<FSSM::Tree::Cache:0x00000600730888 @children={}>
cache.set "/tmp/foo"
# => 2014-02-13 23:20:19 +0900
cache.files
# => {"//tmpfoo"=>2014-02-13 23:20:19 +0900}
# Oops!!! The path is corrupted. It's a problem!!!
```

after:

```
FSSM::Pathname.for("/cygdrive/c/tmp/foo").segments
# => ["/", "cygdrive", "c", "tmp", "foo"]
FSSM::Pathname.for("/cygdrive/c/tmp/foo").join("bar")
# => #<Pathname:/cygdrive/c/tmp/foo/bar>
# OK, no problem. A result of segments is also reasonable.

FSSM::Pathname.for("//host/share/foo").segments
# => ["//host/share", "foo"]
FSSM::Pathname.for("//host/share/foo").join("bar")
# => #<Pathname://host/share/foo/bar>
# OK, no problem. A result of segments is also reasonable.

cache = FSSM::Tree::Cache.new
# => #<FSSM::Tree::Cache:0x00000600272878 @children={}>
cache.set "/tmp/foo"
# => 2014-02-13 23:20:19 +0900
cache.files
# => {"/tmp/foo"=>2014-02-13 23:20:19 +0900}
# OK, fixed a problem.
```
