### PR TITLE
Fixed FSSM::Pathname.segments method to work correctly.

### DIFF
--- a/lib/fssm/pathname.rb
+++ b/lib/fssm/pathname.rb
@@ -21,11 +21,13 @@ module FSSM
     def segments
       path  = to_s
       array = []
-      while !Pathname.new(path).root? && !path.empty?
+      curdir = File.dirname("")
+      while !Pathname.new(path).root? && !(path.empty? || path == curdir)
         array.unshift File.basename(path)
         path        = File.dirname(path)
       end
-      array.unshift path unless path.empty?
+      suffix = path[-1] =~ Pathname::SEPARATOR_PAT ? "" : File::SEPARATOR
+      array.unshift "#{path}#{suffix}" unless path.empty? || path == curdir
       array
     end
 


### PR DESCRIPTION
Maybe, this problem occurs only under the cygwin environment.
The FSSM::Pathname.segments method did not work correctly. Therefore reconnection with join method failed to insert File::SEPARA

This problem makes failure for watch sub-command of compass (http://compass-style.org/).

before:

```
FSSM::Pathname.for("/tmp/foo").segments
# => ["//", "tmp", "foo"]
FSSM::Pathname.for("/tmp/foo").join("bar")
# => #<Pathname:/tmp/foo/bar>
# OK, no problem. But a result of segments is a little bit strange.

FSSM::Pathname.for("//host/share/foo").segments
# => ["//", "host", "share", "foo"]
FSSM::Pathname.for("//host/share/foo").join("bar")
# => #<Pathname://host/share/foo/bar>
# OK, no problem. But a result of segments is a little bit strange.

cache = FSSM::Tree::Cache.new
# => #<FSSM::Tree::Cache:0x00000600730888 @children={}>
cache.set "/tmp/foo"
# => 2014-02-13 23:20:19 +0900
cache.files
# => {"//tmpfoo"=>2014-02-13 23:20:19 +0900}
# Oops!!! The path is corrupted. It's a problem!!!
```

after:

```
FSSM::Pathname.for("/tmp/foo").segments
# => ["/", "tmp", "foo"]
FSSM::Pathname.for("/tmp/foo").join("bar")
# => #<Pathname:/tmp/foo/bar>
# OK, no problem. A result of segments is also reasonable.

FSSM::Pathname.for("//host/share/foo").segments
# => ["//host/share", "foo"]
FSSM::Pathname.for("//host/share/foo").join("bar")
# => #<Pathname://host/share/foo/bar>
# OK, no problem. A result of segments is also reasonable.

cache = FSSM::Tree::Cache.new
# => #<FSSM::Tree::Cache:0x00000600272878 @children={}>
cache.set "/tmp/foo"
# => 2014-02-13 23:20:19 +0900
cache.files
# => {"/tmp/foo"=>2014-02-13 23:20:19 +0900}
# OK, fixed a problem.
```
