### PR TITLE
Bugfix for FSSM::Tree::Cache on UNC.

### DIFF
--- a/lib/fssm/pathname.rb
+++ b/lib/fssm/pathname.rb
@@ -21,11 +21,13 @@ module FSSM
     def segments
       path  = to_s
       array = []
-      while !Pathname.new(path).root? && !path.empty?
+      curdir = File.dirname("")
+      while !Pathname.new(path).root? && !(path.empty? || path == curdir)
         array.unshift File.basename(path)
         path        = File.dirname(path)
       end
-      array.unshift path unless path.empty?
+      suffix = path[-1] =~ Pathname::SEPARATOR_PAT ? "" : File::SEPARATOR
+      array.unshift "#{path}#{suffix}" unless path.empty? || path == curdir
       array
     end
 


### PR DESCRIPTION
Maybe, this problem occurs only under the cygwin environment.

Cause of a problem:

```
Pathname("//host/share").join("hoge.txt")
# => #<Pathname://host/sharehoge.txt>
Pathname("//host/share/").join("hoge.txt")
# => #<Pathname://host/share/hoge.txt>
```

This makes corruption at FSSM::Pathname.for().join() in FSSM::Tree::NodeEnumerable.each().
Therefore FSSM::Tree::Cache.files is not work correctly on UNC.
This patch modifies the behavior as below.

before:

```
FSSM::Pathname.for("//host/share/hoge.txt").segments
# => ["//host/share", "hoge.txt"]
cache = FSSM::Tree::Cache.new
# => #<FSSM::Tree::Cache:0x00000600440b28 @children={}>
cache.set "//host/share/hoge.txt"
# => 2014-02-25 11:38:19 +0900
cache.files
# => {"//host/sharehoge.txt"=>2014-02-25 11:38:19 +0900}
```

after:

```
FSSM::Pathname.for("//host/share/hoge.txt").segments
# => ["//host/share/", "hoge.txt"]
cache = FSSM::Tree::Cache.new
# => #<FSSM::Tree::Cache:0x0000060003e660 @children={}>
cache.set "//host/share/hoge.txt"
# => 2014-02-25 11:38:19 +0900
cache.files
# => {"//host/share/hoge.txt"=>2014-02-25 11:38:19 +0900}
```
