### PR TITLE
Fix tests for new rspec versions

### DIFF
--- a/spec/monitor_spec.rb
+++ b/spec/monitor_spec.rb
@@ -59,7 +59,7 @@ describe "The File System State Monitor" do
       it "should call create callback upon file creation" do
         run_monitor(1) do
           file = @tmp_dir + "/newfile.rb"
-          File.exists?(file).should be_false
+          File.exists?(file).should be_falsey
           FileUtils.touch file
         end
         @handler_results[:create].should == [[@tmp_dir, 'newfile.rb']]


### PR DESCRIPTION
For rspec versions >= 3, the method "be_false", does not exist anymore. Therefore, in order to fix that, it is necessary to change the method to "be_falsey", which is the new method name.