### PR TITLE
fixed not working use rb-inotify

### DIFF
--- a/lib/fssm/support.rb
+++ b/lib/fssm/support.rb
@@ -12,7 +12,7 @@ module FSSM::Support
           'Polling'
       end
     end
-    
+
     def optimal_backend_dependency
       return case
         when mac?     then  ['rb-fsevent', '>= 0.4.3.1']
@@ -54,7 +54,11 @@ module FSSM::Support
       begin
         require 'rb-inotify'
         if defined?(INotify::VERSION)
-          version = INotify::VERSION
+          if INotify::VERSION.is_a?(Array)
+            version = INotify::VERSION
+          else
+            version = INotify::VERSION.split('.').map(&:to_i)
+          end
           version[0] > 0 || version[1] >= 6
         end
       rescue LoadError


### PR DESCRIPTION
## ENV
OS: Ubuntu 14.04
Ruby Version: ruby 2.3.1p112 (2016-04-26 revision 54768) [x86_64-linux]
rb-inotify Version: 0.9.10

## Backtrace

```
/home/vagrant/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/fssm-0.2.10/lib/fssm/support.rb:58:in `>': comparison of String with 0 failed (ArgumentError)
	from /home/vagrant/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/fssm-0.2.10/lib/fssm/support.rb:58:in `rb_inotify?'
	from /home/vagrant/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/fssm-0.2.10/lib/fssm/support.rb:9:in `usable_backend'
	from /home/vagrant/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/fssm-0.2.10/lib/fssm/support.rb:25:in `backend'
	from /home/vagrant/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/fssm-0.2.10/lib/fssm.rb:54:in `const_missing'
	from /home/vagrant/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/fssm-0.2.10/lib/fssm/monitor.rb:4:in `initialize'
	from /home/vagrant/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/fssm-0.2.10/lib/fssm.rb:67:in `new'
	from /home/vagrant/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/fssm-0.2.10/lib/fssm.rb:67:in `monitor'
	from app.rb:15:in `<main>'
```

rb-inotify version became a character instead of an array
Please see this commit

https://github.com/guard/rb-inotify/commit/528f86a44d7198a44ed2245b59de324e8a819855#diff-0b88808273f0e0364e42dd1445b8f1e5R23

So, I Fix it.